### PR TITLE
Enable TypeScript build in Dockerfile

### DIFF
--- a/src/Heuristic.PathfindingLab/Heuristic.PathfindingLab/Dockerfile
+++ b/src/Heuristic.PathfindingLab/Heuristic.PathfindingLab/Dockerfile
@@ -1,12 +1,18 @@
+FROM node:alpine AS typescript
+WORKDIR /app
+COPY . ./
+RUN npm install typescript -g
+RUN tsc -p tsconfig.json
+
 FROM microsoft/dotnet:sdk AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
-COPY *.csproj ./
+COPY --from=typescript /app/*.csproj ./
 RUN dotnet restore
 
 # Copy everything else and build
-COPY . ./
+COPY --from=typescript /app ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image


### PR DESCRIPTION
This pull request fixes the issue where TypeScript files are not compiled during Docker build process. 